### PR TITLE
Refactoring Jupyter Notebooks

### DIFF
--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 # *****************************************************************************
 # Copyright (c) 2022, Intel Corporation All rights reserved.
 #
@@ -119,3 +120,147 @@ intersphinx_mapping = {
 
 # -- Prepend module name to an object name or not -----------------------------------
 add_module_names = False
+=======
+# *****************************************************************************
+# Copyright (c) 2022, Intel Corporation All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#     Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *****************************************************************************
+
+# coding: utf-8
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information -----------------------------------------------------
+
+project = 'Data Parallel Extensions for Python*'
+copyright = '2022, Intel Corporation'
+author = 'Intel Corporation'
+
+# The full version, including alpha/beta/rc tags
+release = '0.1'
+
+# -- General configuration ----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.todo',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosectionlabel',
+    'sphinxcontrib.programoutput',
+    'sphinxcontrib.googleanalytics',
+    'nbsphinx',
+    'nbsphinx_link',
+]
+
+googleanalytics_id = 'G-KVSVYMBQ0W'
+googleanalytics_enabled = True
+
+# Add any paths that contain templates here, relative to this directory.
+#templates_path = ['_templates']
+templates_path = []
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sdc-sphinx-theme'
+
+html_theme_path = ['.']
+
+html_theme_options = {
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = []
+
+html_sidebars = {
+    '**': ['globaltoc.html', 'sourcelink.html', 'searchbox.html', 'relations.html'],
+}
+
+html_show_sourcelink = False
+
+# -- Todo extension configuration  ----------------------------------------------
+todo_include_todos = True
+todo_link_only = True
+
+# -- InterSphinx configuration: looks for objects in external projects -----
+# Add here external classes you want to link from Intel SDC documentation
+# Each entry of the dictionary has the following format:
+#      'class name': ('link to object.inv file for that class', None)
+#intersphinx_mapping = {
+#    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+#    'python': ('http://docs.python.org/2', None),
+#    'numpy': ('http://docs.scipy.org/doc/numpy', None)
+#}
+intersphinx_mapping = {
+}
+
+# -- Napoleon extension configuration (Numpy and Google docstring options) -------
+#napoleon_google_docstring = True
+#napoleon_numpy_docstring = True
+#napoleon_include_init_with_doc = True
+#napoleon_include_private_with_doc = True
+#napoleon_include_special_with_doc = True
+#napoleon_use_admonition_for_examples = False
+#napoleon_use_admonition_for_notes = False
+#napoleon_use_admonition_for_references = False
+#napoleon_use_ivar = False
+#napoleon_use_param = True
+#napoleon_use_rtype = True
+
+# -- Prepend module name to an object name or not -----------------------------------
+add_module_names = False
+
+# -- Copy notebooks into ./docs/sources/notebooks -----------------------------------
+notebooks_src_path = "../../notebooks"
+notebooks_dst_path = "notebooks"
+
+import shutil, errno
+from pathlib import Path
+
+dirpath = Path(notebooks_dst_path)
+if dirpath.exists() and dirpath.is_dir():
+    shutil.rmtree(dirpath)
+
+try:
+    shutil.copytree(notebooks_src_path, notebooks_dst_path)
+except OSError as exc: # python >2.5
+    if exc.errno in (errno.ENOTDIR, errno.EINVAL):
+        shutil.copy(notebooks_src_path, notebooks_dst_path)
+    else:
+        raise
+>>>>>>> Stashed changes

--- a/docs/sources/jupiter_notebook.rst
+++ b/docs/sources/jupiter_notebook.rst
@@ -1,0 +1,14 @@
+.. _jupiter_notebook:
+.. include:: ./ext_links.txt
+
+Jupyter* Notebooks
+******************
+
+Jupyter Notebooks illustrating the usage of **Data Parallel Extensions for Python**.
+
+.. toctree::
+   :maxdepth: 0
+
+   1. Getting Started <notebooks/01-get_started.ipynb>
+   2. Controlling `dpnp` fallback to `numpy` <notebooks/02-dpnp_numpy_fallback.ipynb>
+

--- a/docs/sources/notebooks/01-get_started.ipynb
+++ b/docs/sources/notebooks/01-get_started.ipynb
@@ -1,0 +1,581 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a002ea61",
+   "metadata": {},
+   "source": [
+    "# Getting Started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "905c742a",
+   "metadata": {},
+   "source": [
+    "# Few Line Changes to Run on GPU"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41bf2099",
+   "metadata": {},
+   "source": [
+    "Let's see the example how you can easily in a few lines of code switch computations from CPU to GPU device.\n",
+    "\n",
+    "Please look on the original example.\n",
+    "We allocate 2 matrices on the Host (CPU) device usnig NumPy array function, all future calculations will be performed as well on the allocated Host(CPU) device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d9e8711d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "res =  [[2 2]\n",
+      " [2 2]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Original CPU script\n",
+    "\n",
+    "# Call numpy library\n",
+    "import numpy as np\n",
+    "\n",
+    "# Data alocated on the CPU device\n",
+    "x = np.array([[1, 1], [1, 1]])\n",
+    "y = np.array([[1, 1], [1, 1]])\n",
+    "\n",
+    "# Compute performed on the CPU device, where data is allocated\n",
+    "res = np.matmul(x, y)\n",
+    "\n",
+    "print (\"res = \", res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "402c3d61",
+   "metadata": {},
+   "source": [
+    "Now let's try to modify our code in a way when all calculations occur on the GPU device.\n",
+    "To do it, you need just to switch to the dpnp library and see on the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c10b7d83",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Array x is located on the device: Device(level_zero:gpu:0)\n",
+      "Array y is located on the device: Device(level_zero:gpu:0)\n",
+      "res is located on the device: Device(level_zero:gpu:0)\n",
+      "res =  [[2 2]\n",
+      " [2 2]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modified XPU script\n",
+    "\n",
+    "# Drop-in replacement via single line change\n",
+    "import dpnp as np\n",
+    "\n",
+    "# Data alocated on default SYCL device\n",
+    "x = np.array([[1, 1], [1, 1]])\n",
+    "y = np.array([[1, 1], [1, 1]])\n",
+    "\n",
+    "# Compute performed on the device, where data is allocated\n",
+    "res = np.matmul(x, y)\n",
+    "\n",
+    "\n",
+    "print (\"Array x is located on the device:\", x.device)\n",
+    "print (\"Array y is located on the device:\", y.device)\n",
+    "print (\"res is located on the device:\", res.device)\n",
+    "print (\"res = \", res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6a58f17",
+   "metadata": {},
+   "source": [
+    "As you may see changing only one line of code help us to perform all calculations on the GPU device.\n",
+    "In this example np.array() creates an array on the default SYCL* device, which is \"gpu\" on systems with integrated or discrete GPU (it is \"host\" on systems that do not have GPU). The queue associated with this array is now carried with x and y, and np.matmul(x, y) will do matrix product of two arrays x and y, and respective pre-compiled kernel implementing np.matmul() will be submitted to that queue. The result res will be allocated on the device array associated with that queue too.\n",
+    "\n",
+    "Now let's make a few improvements in our code and see how we can control and specify exact device on which we want to perform our calculations and which USM memory type to use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be340585",
+   "metadata": {},
+   "source": [
+    "# dpnp simple examples with popular functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26d8c3c6",
+   "metadata": {},
+   "source": [
+    "1. Example to return an array with evenly spaced values within a given interval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "0435d7f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "282 µs ± 27.6 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)\n",
+      "Result a is located on the device: Device(level_zero:gpu:0)\n",
+      "a =  [ 3  9 15 21 27]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "# Create an array of values from 3 till 30 with step 6\n",
+    "a = np.arange(3, 30, step = 6)\n",
+    "\n",
+    "print (\"Result a is located on the device:\", a.device)\n",
+    "print (\"a = \", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6765095",
+   "metadata": {},
+   "source": [
+    "In this example np.arange() creates an array on the default SYCL* device, which is \"gpu\" on systems with integrated or discrete GPU (it is \"host\" on systems that do not have GPU)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35081461",
+   "metadata": {},
+   "source": [
+    "2. Example which calculates on the GPU the sum of the array elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e613398f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result x is located on the device: Device(level_zero:gpu:0)\n",
+      "Result y is located on the device: Device(level_zero:gpu:0)\n",
+      "The sum of the array elements is:  6\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "x = np.empty(3)\n",
+    "\n",
+    "try:\n",
+    "    # Using filter selector strings to specify root devices for a new array\n",
+    "    x = np.asarray ([1, 2, 3], device=\"gpu\")\n",
+    "    print (\"Result x is located on the device:\", x.device)\n",
+    "except:\n",
+    "    print (\"GPU device is not available\")\n",
+    "\n",
+    "# Return the sum of the array elements\n",
+    "y = np.sum (x) # Expect 6\n",
+    "\n",
+    "print (\"Result y is located on the device:\", y.device)\n",
+    "print (\"The sum of the array elements is: \", y )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b4915e",
+   "metadata": {},
+   "source": [
+    "In this example np.asarray() creates an array on the default GPU device. The queue associated with this array is now carried with x, and np.sum(x) will derive it from x, and respective pre-compiled kernel implementing np.sum() will be submitted to that queue. The result y will be allocated on the device 0-dimensional array associated with that queue too."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b49f4c62",
+   "metadata": {},
+   "source": [
+    "3. Example of inversion of an array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4b53afed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Array a is located on the device: Device(level_zero:gpu:0)\n",
+      "Result x is located on the device: Device(level_zero:gpu:0)\n",
+      "Array x is: [[-2 -2]\n",
+      " [-3 -2]\n",
+      " [-2 -1]\n",
+      " [ 0 -1]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "try:\n",
+    "    \n",
+    "    # Using filter selector strings to specify root devices for an array\n",
+    "    a = np.array([[1, 1], [2, 1], [1, 0], [-1, 0]], device = \"gpu\")\n",
+    "    print (\"Array a is located on the device:\", a.device)  \n",
+    "\n",
+    "    # Do inversion of an array \"a\"\n",
+    "    x = np.invert(a)\n",
+    "\n",
+    "    print (\"Result x is located on the device:\", x.device)\n",
+    "    print (\"Array x is:\", x) \n",
+    "\n",
+    "except:\n",
+    "    print (\"GPU device is not available\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10f226a",
+   "metadata": {},
+   "source": [
+    "In this example np.array() creates an array on the default GPU device. The queue associated with this array is now carried with a, and np.invert(a) will derive it from a, and respective pre-compiled kernel implementing np.invert() will be submitted to that queue. The result x will be allocated on the device array associated with that queue too."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94cb3b9b",
+   "metadata": {},
+   "source": [
+    "# dpctl simple examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb4b1b5",
+   "metadata": {},
+   "source": [
+    "Here you may find a list of simple examples which explain how to understand how many devices you have in the systen and how to operate with them\n",
+    "Let's print the list of all available SYCL devices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b890ae71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intel(R) OpenCL HD Graphics OpenCL 3.0 \n",
+      "Intel(R) FPGA Emulation Platform for OpenCL(TM) OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3\n",
+      "Intel(R) OpenCL OpenCL 3.0 WINDOWS\n",
+      "Intel(R) Level-Zero 1.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See the list of available SYCL platforms and extra metadata about each platform.\n",
+    "import dpctl\n",
+    "\n",
+    "dpctl.lsplatform()  # Print platform information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5e8db4",
+   "metadata": {},
+   "source": [
+    "Let's look on the output.\n",
+    "On my platform is available OpenCL GPU driver, Intel(R) FPGA Emulation Device, OpenCL CPU driver and Level Zero GPU driver.\n",
+    "If i play with verbocity parameter, i can get more information about the devices i have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ffcf0cfb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Platform  0 ::\n",
+      "    Name        Intel(R) OpenCL HD Graphics\n",
+      "    Version     OpenCL 3.0 \n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     opencl\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) Iris(R) Xe Graphics\n",
+      "        Version             31.0.101.3430\n",
+      "        Filter string       opencl:gpu:0\n",
+      "Platform  1 ::\n",
+      "    Name        Intel(R) FPGA Emulation Platform for OpenCL(TM)\n",
+      "    Version     OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3\n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     opencl\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) FPGA Emulation Device\n",
+      "        Version             2022.15.11.0.18_160000\n",
+      "        Filter string       opencl:accelerator:0\n",
+      "Platform  2 ::\n",
+      "    Name        Intel(R) OpenCL\n",
+      "    Version     OpenCL 3.0 WINDOWS\n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     opencl\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz\n",
+      "        Version             2022.15.11.0.18_160000\n",
+      "        Filter string       opencl:cpu:0\n",
+      "Platform  3 ::\n",
+      "    Name        Intel(R) Level-Zero\n",
+      "    Version     1.3\n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     ext_oneapi_level_zero\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) Iris(R) Xe Graphics\n",
+      "        Version             1.3.23904\n",
+      "        Filter string       level_zero:gpu:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See the list of available SYCL platforms and extra metadata about each platform.\n",
+    "import dpctl\n",
+    "\n",
+    "dpctl.lsplatform(2)  # Print platform information with verbocitz level 2 (highest level)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f63525d3",
+   "metadata": {},
+   "source": [
+    "Having information about available SYCL platforms you can specify which type of devices you want to work with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "84ff47e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<dpctl.SyclDevice [backend_type.opencl, device_type.gpu,  Intel(R) Iris(R) Xe Graphics] at 0x1a1eddd72f0>, <dpctl.SyclDevice [backend_type.level_zero, device_type.gpu,  Intel(R) Iris(R) Xe Graphics] at 0x1a1eddd70f0>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See the list of available gpu devices and their extra metadata.\n",
+    "import dpctl\n",
+    "\n",
+    "if dpctl.has_gpu_devices():\n",
+    "    print (dpctl.get_devices(device_type='gpu'))\n",
+    "else:\n",
+    "    print(\"GPU device is not available\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a93e7cf8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<dpctl.SyclDevice [backend_type.opencl, device_type.cpu,  11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz] at 0x1779083bcf0>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See the list of available gpu devices and their extra metadata.\n",
+    "import dpctl\n",
+    "\n",
+    "if dpctl.has_cpu_devices():\n",
+    "    print (dpctl.get_devices(device_type='cpu'))\n",
+    "else:\n",
+    "    print(\"CPU device is not available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efcc3f45",
+   "metadata": {},
+   "source": [
+    "And you can make selection of the specific device in your system using the default selctor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1c068447",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) Iris(R) Xe Graphics\n",
+      "    Driver version  1.3.23904\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "try:\n",
+    "    # Create a SyclDevice of type GPU based on whatever is returned\n",
+    "    # by the SYCL `gpu_selector` device selector class.\n",
+    "    gpu = dpctl.select_gpu_device()\n",
+    "    gpu.print_device_info() # print GPU device information\n",
+    "\n",
+    "except:\n",
+    "    print (\"GPU device is not available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c378b79d",
+   "metadata": {},
+   "source": [
+    "Or by using the infromation in filter string of the device create abd explicit SyclDevice "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ad83abb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) Iris(R) Xe Graphics\n",
+      "    Driver version  1.3.23904\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Profile         FULL_PROFILE\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "# Create a SyclDevice with an explicit filter string,\n",
+    "# in this case the first level_zero gpu device.\n",
+    "try:\n",
+    "    level_zero_gpu = dpctl.SyclDevice(\"level_zero:gpu:0\")\n",
+    "    level_zero_gpu.print_device_info()\n",
+    "except:\n",
+    "    print(\"The first level_zero GPU device is not available\")    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eadefe0b",
+   "metadata": {},
+   "source": [
+    "Let's check if your gpu device support double precision. To do this we need to selcet gpu device and check the parameter has_aspect_fp64:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a94756d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) Iris(R) Xe Graphics\n",
+      "    Driver version  1.3.23904\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Double precision support is False\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "# Select GPU device and check double precision support\n",
+    "try:\n",
+    "    gpu = dpctl.select_gpu_device()\n",
+    "    gpu.print_device_info()\n",
+    "    print(\"Double precision support is\", gpu.has_aspect_fp64)\n",
+    "except:\n",
+    "    print(\"The GPU device is not available\")   "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/sources/notebooks/02-dpnp_numpy_fallback.ipynb
+++ b/docs/sources/notebooks/02-dpnp_numpy_fallback.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be340585",
+   "metadata": {},
+   "source": [
+    "# Usage of numpy functions in dpnp library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9008dbe5",
+   "metadata": {},
+   "source": [
+    "1. Example of the usage of the `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` environment variable and finding specific values in array based on condition using dpnp library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d4300fe",
+   "metadata": {},
+   "source": [
+    "Not all functions were yet implemented in the dpnp library, some of the functions require enabling of the direct fallback to the NumPy library. \n",
+    "One of the example can be the function \"dpnp.full ()\" and parameter like in non default state. \n",
+    "Let's look on the example where we want to create an two dimencial array with singular element and array like option. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c78511cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "Requested funtion=full with args=((2, 2), 3, None, 'C') and kwargs={'like': <dpnp.dpnp_array.dpnp_array object at 0x0000021C7FAAF8B0>} isn't currently supported and would fall back on NumPy implementation. Define enviroment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` if the fall back is required to be supported without rasing an exception.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[1], line 4\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mdpnp\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;66;03m# Create an two dimencial array with singular element and array like option\u001b[39;00m\n\u001b[1;32m----> 4\u001b[0m a \u001b[38;5;241m=\u001b[39m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfull\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m3\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlike\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mzeros\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      5\u001b[0m \u001b[38;5;28mprint\u001b[39m (\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mArray a is located on the device:\u001b[39m\u001b[38;5;124m\"\u001b[39m, a\u001b[38;5;241m.\u001b[39mdevice)\n\u001b[0;32m      6\u001b[0m \u001b[38;5;28mprint\u001b[39m (\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mArray a is\u001b[39m\u001b[38;5;124m\"\u001b[39m, a)\n",
+      "File \u001b[1;32m~\\Anaconda3\\envs\\my_env\\lib\\site-packages\\dpnp\\dpnp_iface_arraycreation.py:732\u001b[0m, in \u001b[0;36mfull\u001b[1;34m(shape, fill_value, dtype, order, like, device, usm_type, sycl_queue)\u001b[0m\n\u001b[0;32m    723\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m    724\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m dpnp_container\u001b[38;5;241m.\u001b[39mfull(shape,\n\u001b[0;32m    725\u001b[0m                                fill_value,\n\u001b[0;32m    726\u001b[0m                                dtype\u001b[38;5;241m=\u001b[39mdtype,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m    729\u001b[0m                                usm_type\u001b[38;5;241m=\u001b[39musm_type,\n\u001b[0;32m    730\u001b[0m                                sycl_queue\u001b[38;5;241m=\u001b[39msycl_queue)\n\u001b[1;32m--> 732\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mcall_origin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnumpy\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfull\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshape\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfill_value\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43morder\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlike\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlike\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[1;32mdpnp\\dpnp_utils\\dpnp_algo_utils.pyx:132\u001b[0m, in \u001b[0;36mdpnp.dpnp_utils.dpnp_algo_utils.call_origin\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;31mNotImplementedError\u001b[0m: Requested funtion=full with args=((2, 2), 3, None, 'C') and kwargs={'like': <dpnp.dpnp_array.dpnp_array object at 0x0000021C7FAAF8B0>} isn't currently supported and would fall back on NumPy implementation. Define enviroment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` if the fall back is required to be supported without rasing an exception."
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "# Create an two dimencial array with singular element and array like option\n",
+    "a = np.full((2,2),3, like = np.zeros((2, 0)))\n",
+    "print (\"Array a is located on the device:\", a.device)\n",
+    "print (\"Array a is\", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae026021",
+   "metadata": {},
+   "source": [
+    "As you can see the function \"dpnp.full ()\" and parameter like in non default state is not implemented in the dpnp library.\n",
+    "We got the following error message: \"Requested funtion=full with args=((2, 2), 3, None, 'C') and kwargs={'like': <dpnp.dpnp_array.dpnp_array object at 0x0000021C7FAAF8B0>} isn't currently supported and would fall back on NumPy implementation. Define environment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` if the fall back is required to be supported without raising an exception.\" \n",
+    "By default the `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` environment variable is not null and it allows to use only dpnp library. \n",
+    "If we want to call NumPy library for functions not supported under dpnp, we need to change this environment variable to `0`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "210440c3",
+   "metadata": {},
+   "source": [
+    "Let's overwrite the same example using the `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0` environment variable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bca7490d",
+   "metadata": {},
+   "source": [
+    "`Note:` Please pay attention that if you are working in the Jupyter Notebook, before running the example with setting the  `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0` you need to restart the kernel in the Jupyter Notebook. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "05ad1565",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0\n",
+      "Array a is located on the device: Device(level_zero:gpu:0)\n",
+      "Array a is [[3 3]\n",
+      " [3 3]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "# call numpy if not null than we will use dpnp, by default not null\n",
+    "os.environ[\"DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK\"] = \"0\" \n",
+    "\n",
+    "import dpnp as np\n",
+    "\n",
+    "# Expect result 0\n",
+    "print (\"DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK =\", np.config.__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__) \n",
+    "\n",
+    "# Create an two dimencial array with singular element and array like option\n",
+    "a = np.full((2,2),3, like = np.zeros((2, 0)))\n",
+    "print (\"Array a is located on the device:\", a.device)\n",
+    "print (\"Array a is\", a)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,8 @@ dependencies:
     - sphinx
     - sphinxcontrib-programoutput 
     - sphinxcontrib-googleanalytics
+<<<<<<< Updated upstream
+=======
+    - nbsphinx
+    - nbconvert
+>>>>>>> Stashed changes

--- a/notebooks/.ipynb_checkpoints/01-get_started-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/01-get_started-checkpoint.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a002ea61",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Getting started with Data Parallel Extensions for Python\n",
+    "<img src=\"https://intelpython.github.io/DPEP/main/_images/DPEP-large.png\" width=\"300\"/>\n",
+    "\n",
+    "[Data Parallel Extensions for Python](https://intelpython.github.io/DPEP/main/) allow you to run NumPy-like code beyond CPU using **Data Parallel Extension for NumPy**. It will also allow you to compile the code using **Data Parallel Extension for Numba**. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0565bf88-a3e9-4ee3-a815-3efe977c2a8f",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## Modifying CPU script to run on GPU\n",
+    "\n",
+    "In many cases the process of running Python on GPU is about making minor changes to your CPU script, which are:\n",
+    "1. Changing import statement(s)\n",
+    "2. Specifying on which device(s) the data is allocated\n",
+    "3. Explicitly copying data between devices and the host as needed\n",
+    "\n",
+    "We will illustrate these concepts on series of short examples. Let's assume we have the following NumPy script originally written to run on CPU, which is nothing more than creating two matrices `x` and `y` and performing matrix-matrix multiplication with `numpy.matmul()`, and prining the resulting matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d9e8711d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[2 2]\n",
+      " [2 2]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CPU script for matrix-matrix multiplication using NumPy\n",
+    "\n",
+    "# 1. Import numpy\n",
+    "import numpy as np\n",
+    "\n",
+    "# 2. Create two matrices\n",
+    "x = np.array([[1, 1], [1, 1]])\n",
+    "y = np.array([[1, 1], [1, 1]])\n",
+    "\n",
+    "# 3. Perform matrix-matrix multiplication\n",
+    "res = np.matmul(x, y)\n",
+    "\n",
+    "# 4. Print resulting matrix\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "402c3d61",
+   "metadata": {},
+   "source": [
+    "As stated before in many cases to run the same code on GPU is a trivial modification of a few lines of the code, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c10b7d83",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[2 2]\n",
+      " [2 2]]\n",
+      "Array x is allocated on the device: Device(level_zero:gpu:0)\n",
+      "Array y is allocated on the device: Device(level_zero:gpu:0)\n",
+      "res is allocated on the device: Device(level_zero:gpu:0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modified script to run the same code on GPU using dpnp\n",
+    "\n",
+    "# 1. Import dpnp\n",
+    "import dpnp as np  # Note, we changed the import statement. Since dpnp is a drop-in replacement of numpy the rest of the code will run lik regular numpy\n",
+    "\n",
+    "# 2. Create two matrices\n",
+    "x = np.array([[1, 1], [1, 1]])\n",
+    "y = np.array([[1, 1], [1, 1]])\n",
+    "\n",
+    "# 3. Perform matrix-matrix multiplication\n",
+    "res = np.matmul(x, y)\n",
+    "\n",
+    "# 4. Print what's going on under the hood\n",
+    "print(res)\n",
+    "print(\"Array x is allocated on the device:\", x.device)\n",
+    "print(\"Array y is allocated on the device:\", y.device)\n",
+    "print(\"res is allocated on the device:\", res.device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6a58f17",
+   "metadata": {},
+   "source": [
+    "Let's see what we actually changed.\n",
+    "\n",
+    "1. Obviously we changed the import statement. Now we import `dpnp`, which is a drop-in replacement for a subset of `numpy` that extends numpy-like codes beyond CPU\n",
+    "2. No change in matrix creation code. How does `dpnp` know that matrices `x` and `y` need to be allocated on GPU? This is because, if we do not specify the device explicitly, the driver will use the default device, which is GPU on systems with installed GPU drivers.\n",
+    "3. No change in matrix multiplication code. This is because `dpnp` programming model is the Compute-Follows-Data. It means that `dpnp.matmul()` determines which device will execute an operation based on where array inputs are allocated. Since our inputs `x` and `y` are allocated on the default device (GPU) the matrix-matrix multiplication will follow data allocation and execute on GPU too.\n",
+    "4. Note, arrays `x`, `y`, `res` all have the `device` attribute by printing which we make sure that all inputs are indeed on the GPU device, and the result is also on the GPU deivice. To be precise the data allocation (and execution) happened on GPU device 0 through Level-Zero driver."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be340585",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## More on data allocation and the Compute-Follows-Data\n",
+    "\n",
+    "Sometimes you may want to be specific about the device type, not relying on the default behavior. You can do so by specifying the device in a keyword arguments for `dpnp` array creation functions and random number generators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0435d7f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "a = np.arange(3, 30, step = 6, device=\"gpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6765095",
+   "metadata": {},
+   "source": [
+    "`dpnp.arange()` is the array creation function that has optional keyword argument `device`, using which you can specify the device you want data to be allocated on with filter selector string. In our case the string specifies device type `\"gpu\"`. The proper way of handling situations when the specified device is not available would be as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e613398f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The a is allocated on the device: Device(level_zero:gpu:0)\n",
+      "Reduction sum y:  75\n",
+      "Result y is located on the device: Device(level_zero:gpu:0)\n",
+      "y.shape= ()\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "try:\n",
+    "    a = np.arange(3, 30, step = 6, device=\"gpu\")\n",
+    "    print(\"The a is allocated on the device:\", a.device)\n",
+    "except:\n",
+    "    print(\"GPU device is not available\")\n",
+    "    # Do some fallback code\n",
+    "\n",
+    "# Do reduction on the selected device\n",
+    "y = np.sum(a)\n",
+    "\n",
+    "print(\"Reduction sum y: \", y)  # Expect 75\n",
+    "print(\"Result y is located on the device:\", y.device)\n",
+    "print(\"y.shape=\", y.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b4915e",
+   "metadata": {},
+   "source": [
+    "Note that `y` is itself a device array (not a scalar!), its data resides on the same device as input array `a`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94cb3b9b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Advanced data and device control with Data Parallel Control library `dpctl`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb4b1b5",
+   "metadata": {},
+   "source": [
+    "Data Parallel Control library, `dpctl`, among other things provide advanced capabilities for controling devices and data. Among its useful functions is `dpctl.lsplatform(verbosity)`, printing information about the list of available devices on the system with different levels of verbosity:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b890ae71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intel(R) OpenCL HD Graphics OpenCL 3.0 \n",
+      "Intel(R) Level-Zero 1.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "dpctl.lsplatform()  # Print platform information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5e8db4",
+   "metadata": {},
+   "source": [
+    "Using a different verbosity setting to print extra meta-data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ffcf0cfb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Platform  0 ::\n",
+      "    Name        Intel(R) OpenCL HD Graphics\n",
+      "    Version     OpenCL 3.0 \n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     opencl\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) UHD Graphics 620\n",
+      "        Version             31.0.101.2111\n",
+      "        Filter string       opencl:gpu:0\n",
+      "Platform  1 ::\n",
+      "    Name        Intel(R) Level-Zero\n",
+      "    Version     1.3\n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     ext_oneapi_level_zero\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) UHD Graphics 620\n",
+      "        Version             1.3.0\n",
+      "        Filter string       level_zero:gpu:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "dpctl.lsplatform(2)  # Print platform information with verbocitz level 2 (highest level)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f63525d3",
+   "metadata": {},
+   "source": [
+    "You can also query whether system has GPU devices and retrieve respective device objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "84ff47e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This system has 2 GPUs\n",
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  31.0.101.2111\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   opencl:gpu:0\n",
+      "\n",
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Array x is on the device: Device(opencl:gpu:0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "import dpnp as np\n",
+    "\n",
+    "if dpctl.has_gpu_devices():\n",
+    "    devices = dpctl.get_devices(device_type='gpu')\n",
+    "    print(f\"This system has {len(devices)} GPUs\")\n",
+    "    for device in devices:\n",
+    "        device.print_device_info()\n",
+    "        \n",
+    "    x = np.array([1, 2, 3], device=devices[0])  # Another way of selecting on which device to allocate the data\n",
+    "    print(\"Array x is on the device:\", x.device)\n",
+    "else:\n",
+    "    print(\"GPU devices are not available on this system\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0918733-0992-41e8-bfa5-228a080bc165",
+   "metadata": {},
+   "source": [
+    "The following snapshot illustrates how to select the default GPU device using `dpctl` and generate an array of random numbers on this device:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1c068447",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Array x: [0.87253657 0.87415047 0.61092713 0.1395424  0.95248436]\n",
+      "Array x.device: Device(level_zero:gpu:0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    gpu = dpctl.select_gpu_device()\n",
+    "    gpu.print_device_info() # print GPU device information\n",
+    "    x = np.random.random(5, device=gpu)  # Create array of random numbers on the default GPU device\n",
+    "    print(\"Array x:\", x)\n",
+    "    print(\"Array x.device:\", x.device)\n",
+    "except:\n",
+    "    print (\"No GPU devices available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c378b79d",
+   "metadata": {},
+   "source": [
+    "Or by creating GPU device object from the filter selector string:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ad83abb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "try:\n",
+    "    l0_gpu_0 = dpctl.SyclDevice(\"level_zero:gpu:0\")\n",
+    "    l0_gpu_0.print_device_info()\n",
+    "except:\n",
+    "    print(\"Cannot create the device object from a given filter selector string\")    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eadefe0b",
+   "metadata": {},
+   "source": [
+    "The following snapshot checks whether a given device supports certain aspects, which may be important for the application, such as support for float64 (double precision) or the amount of available global memory on the device, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a94756d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Has double precision: True\n",
+      "Has atomic operations support: True\n",
+      "Global memory size: 6284.109375 MB\n",
+      "Global memory cache size: 512.0 KB\n",
+      "Maximum compute units: 24\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "try:\n",
+    "    gpu = dpctl.select_gpu_device()\n",
+    "    gpu.print_device_info()\n",
+    "    print(\"Has double precision:\", gpu.has_aspect_fp64)\n",
+    "    print(\"Has atomic operations support:\", gpu.has_aspect_atomic64)\n",
+    "    print(f\"Global memory size: {gpu.global_mem_size/1024/1024} MB\")\n",
+    "    print(f\"Global memory cache size: {gpu.global_mem_cache_size/1024} KB\")\n",
+    "    print(f\"Maximum compute units: {gpu.max_compute_units}\")\n",
+    "except:\n",
+    "    print(\"The GPU device is not available\")   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97b53113-8264-4f7e-9a9d-a997e70ed3bc",
+   "metadata": {},
+   "source": [
+    "For more information about `dpctl` device selection please refer to [Data Parallel Control: Device Selection](https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html)\n",
+    "\n",
+    "For more information about `dpctl.SyclDevice` class methods and attributes please refer to [Data Parallel Control: dpctl.SyclDevice](https://intelpython.github.io/dpctl/latest/docfiles/dpctl/SyclDevice.html)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/01-get_started.ipynb
+++ b/notebooks/01-get_started.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a002ea61",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Getting started with Data Parallel Extensions for Python\n",
+    "<img src=\"https://intelpython.github.io/DPEP/main/_images/DPEP-large.png\" width=\"300\"/>\n",
+    "\n",
+    "[Data Parallel Extensions for Python](https://intelpython.github.io/DPEP/main/) allow you to run NumPy-like code beyond CPU using **Data Parallel Extension for NumPy**. It will also allow you to compile the code using **Data Parallel Extension for Numba**. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0565bf88-a3e9-4ee3-a815-3efe977c2a8f",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## Modifying CPU script to run on GPU\n",
+    "\n",
+    "In many cases the process of running Python on GPU is about making minor changes to your CPU script, which are:\n",
+    "1. Changing import statement(s)\n",
+    "2. Specifying on which device(s) the data is allocated\n",
+    "3. Explicitly copying data between devices and the host as needed\n",
+    "\n",
+    "We will illustrate these concepts on series of short examples. Let's assume we have the following NumPy script originally written to run on CPU, which is nothing more than creating two matrices `x` and `y` and performing matrix-matrix multiplication with `numpy.matmul()`, and prining the resulting matrix:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d9e8711d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[2 2]\n",
+      " [2 2]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CPU script for matrix-matrix multiplication using NumPy\n",
+    "\n",
+    "# 1. Import numpy\n",
+    "import numpy as np\n",
+    "\n",
+    "# 2. Create two matrices\n",
+    "x = np.array([[1, 1], [1, 1]])\n",
+    "y = np.array([[1, 1], [1, 1]])\n",
+    "\n",
+    "# 3. Perform matrix-matrix multiplication\n",
+    "res = np.matmul(x, y)\n",
+    "\n",
+    "# 4. Print resulting matrix\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "402c3d61",
+   "metadata": {},
+   "source": [
+    "As stated before in many cases to run the same code on GPU is a trivial modification of a few lines of the code, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c10b7d83",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[2 2]\n",
+      " [2 2]]\n",
+      "Array x is allocated on the device: Device(level_zero:gpu:0)\n",
+      "Array y is allocated on the device: Device(level_zero:gpu:0)\n",
+      "res is allocated on the device: Device(level_zero:gpu:0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modified script to run the same code on GPU using dpnp\n",
+    "\n",
+    "# 1. Import dpnp\n",
+    "import dpnp as np  # Note, we changed the import statement. Since dpnp is a drop-in replacement of numpy the rest of the code will run lik regular numpy\n",
+    "\n",
+    "# 2. Create two matrices\n",
+    "x = np.array([[1, 1], [1, 1]])\n",
+    "y = np.array([[1, 1], [1, 1]])\n",
+    "\n",
+    "# 3. Perform matrix-matrix multiplication\n",
+    "res = np.matmul(x, y)\n",
+    "\n",
+    "# 4. Print what's going on under the hood\n",
+    "print(res)\n",
+    "print(\"Array x is allocated on the device:\", x.device)\n",
+    "print(\"Array y is allocated on the device:\", y.device)\n",
+    "print(\"res is allocated on the device:\", res.device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6a58f17",
+   "metadata": {},
+   "source": [
+    "Let's see what we actually changed.\n",
+    "\n",
+    "1. Obviously we changed the import statement. Now we import `dpnp`, which is a drop-in replacement for a subset of `numpy` that extends numpy-like codes beyond CPU\n",
+    "2. No change in matrix creation code. How does `dpnp` know that matrices `x` and `y` need to be allocated on GPU? This is because, if we do not specify the device explicitly, the driver will use the default device, which is GPU on systems with installed GPU drivers.\n",
+    "3. No change in matrix multiplication code. This is because `dpnp` programming model is the Compute-Follows-Data. It means that `dpnp.matmul()` determines which device will execute an operation based on where array inputs are allocated. Since our inputs `x` and `y` are allocated on the default device (GPU) the matrix-matrix multiplication will follow data allocation and execute on GPU too.\n",
+    "4. Note, arrays `x`, `y`, `res` all have the `device` attribute by printing which we make sure that all inputs are indeed on the GPU device, and the result is also on the GPU deivice. To be precise the data allocation (and execution) happened on GPU device 0 through Level-Zero driver."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be340585",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## More on data allocation and the Compute-Follows-Data\n",
+    "\n",
+    "Sometimes you may want to be specific about the device type, not relying on the default behavior. You can do so by specifying the device in a keyword arguments for `dpnp` array creation functions and random number generators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0435d7f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "a = np.arange(3, 30, step = 6, device=\"gpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6765095",
+   "metadata": {},
+   "source": [
+    "`dpnp.arange()` is the array creation function that has optional keyword argument `device`, using which you can specify the device you want data to be allocated on with filter selector string. In our case the string specifies device type `\"gpu\"`. The proper way of handling situations when the specified device is not available would be as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e613398f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The a is allocated on the device: Device(level_zero:gpu:0)\n",
+      "Reduction sum y:  75\n",
+      "Result y is located on the device: Device(level_zero:gpu:0)\n",
+      "y.shape= ()\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "try:\n",
+    "    a = np.arange(3, 30, step = 6, device=\"gpu\")\n",
+    "    print(\"The a is allocated on the device:\", a.device)\n",
+    "except:\n",
+    "    print(\"GPU device is not available\")\n",
+    "    # Do some fallback code\n",
+    "\n",
+    "# Do reduction on the selected device\n",
+    "y = np.sum(a)\n",
+    "\n",
+    "print(\"Reduction sum y: \", y)  # Expect 75\n",
+    "print(\"Result y is located on the device:\", y.device)\n",
+    "print(\"y.shape=\", y.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b4915e",
+   "metadata": {},
+   "source": [
+    "Note that `y` is itself a device array (not a scalar!), its data resides on the same device as input array `a`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94cb3b9b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Advanced data and device control with Data Parallel Control library `dpctl`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb4b1b5",
+   "metadata": {},
+   "source": [
+    "Data Parallel Control library, `dpctl`, among other things provide advanced capabilities for controling devices and data. Among its useful functions is `dpctl.lsplatform(verbosity)`, printing information about the list of available devices on the system with different levels of verbosity:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b890ae71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intel(R) OpenCL HD Graphics OpenCL 3.0 \n",
+      "Intel(R) Level-Zero 1.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "dpctl.lsplatform()  # Print platform information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db5e8db4",
+   "metadata": {},
+   "source": [
+    "Using a different verbosity setting to print extra meta-data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ffcf0cfb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Platform  0 ::\n",
+      "    Name        Intel(R) OpenCL HD Graphics\n",
+      "    Version     OpenCL 3.0 \n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     opencl\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) UHD Graphics 620\n",
+      "        Version             31.0.101.2111\n",
+      "        Filter string       opencl:gpu:0\n",
+      "Platform  1 ::\n",
+      "    Name        Intel(R) Level-Zero\n",
+      "    Version     1.3\n",
+      "    Vendor      Intel(R) Corporation\n",
+      "    Backend     ext_oneapi_level_zero\n",
+      "    Num Devices 1\n",
+      "      # 0\n",
+      "        Name                Intel(R) UHD Graphics 620\n",
+      "        Version             1.3.0\n",
+      "        Filter string       level_zero:gpu:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "dpctl.lsplatform(2)  # Print platform information with verbocitz level 2 (highest level)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f63525d3",
+   "metadata": {},
+   "source": [
+    "You can also query whether system has GPU devices and retrieve respective device objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "84ff47e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This system has 2 GPUs\n",
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  31.0.101.2111\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   opencl:gpu:0\n",
+      "\n",
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Array x is on the device: Device(opencl:gpu:0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "import dpnp as np\n",
+    "\n",
+    "if dpctl.has_gpu_devices():\n",
+    "    devices = dpctl.get_devices(device_type='gpu')\n",
+    "    print(f\"This system has {len(devices)} GPUs\")\n",
+    "    for device in devices:\n",
+    "        device.print_device_info()\n",
+    "        \n",
+    "    x = np.array([1, 2, 3], device=devices[0])  # Another way of selecting on which device to allocate the data\n",
+    "    print(\"Array x is on the device:\", x.device)\n",
+    "else:\n",
+    "    print(\"GPU devices are not available on this system\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0918733-0992-41e8-bfa5-228a080bc165",
+   "metadata": {},
+   "source": [
+    "The following snapshot illustrates how to select the default GPU device using `dpctl` and generate an array of random numbers on this device:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1c068447",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Array x: [0.87253657 0.87415047 0.61092713 0.1395424  0.95248436]\n",
+      "Array x.device: Device(level_zero:gpu:0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    gpu = dpctl.select_gpu_device()\n",
+    "    gpu.print_device_info() # print GPU device information\n",
+    "    x = np.random.random(5, device=gpu)  # Create array of random numbers on the default GPU device\n",
+    "    print(\"Array x:\", x)\n",
+    "    print(\"Array x.device:\", x.device)\n",
+    "except:\n",
+    "    print (\"No GPU devices available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c378b79d",
+   "metadata": {},
+   "source": [
+    "Or by creating GPU device object from the filter selector string:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ad83abb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "try:\n",
+    "    l0_gpu_0 = dpctl.SyclDevice(\"level_zero:gpu:0\")\n",
+    "    l0_gpu_0.print_device_info()\n",
+    "except:\n",
+    "    print(\"Cannot create the device object from a given filter selector string\")    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eadefe0b",
+   "metadata": {},
+   "source": [
+    "The following snapshot checks whether a given device supports certain aspects, which may be important for the application, such as support for float64 (double precision) or the amount of available global memory on the device, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a94756d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Name            Intel(R) UHD Graphics 620\n",
+      "    Driver version  1.3.0\n",
+      "    Vendor          Intel(R) Corporation\n",
+      "    Filter string   level_zero:gpu:0\n",
+      "\n",
+      "Has double precision: True\n",
+      "Has atomic operations support: True\n",
+      "Global memory size: 6284.109375 MB\n",
+      "Global memory cache size: 512.0 KB\n",
+      "Maximum compute units: 24\n"
+     ]
+    }
+   ],
+   "source": [
+    "import dpctl\n",
+    "\n",
+    "try:\n",
+    "    gpu = dpctl.select_gpu_device()\n",
+    "    gpu.print_device_info()\n",
+    "    print(\"Has double precision:\", gpu.has_aspect_fp64)\n",
+    "    print(\"Has atomic operations support:\", gpu.has_aspect_atomic64)\n",
+    "    print(f\"Global memory size: {gpu.global_mem_size/1024/1024} MB\")\n",
+    "    print(f\"Global memory cache size: {gpu.global_mem_cache_size/1024} KB\")\n",
+    "    print(f\"Maximum compute units: {gpu.max_compute_units}\")\n",
+    "except:\n",
+    "    print(\"The GPU device is not available\")   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97b53113-8264-4f7e-9a9d-a997e70ed3bc",
+   "metadata": {},
+   "source": [
+    "For more information about `dpctl` device selection please refer to [Data Parallel Control: Device Selection](https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html)\n",
+    "\n",
+    "For more information about `dpctl.SyclDevice` class methods and attributes please refer to [Data Parallel Control: dpctl.SyclDevice](https://intelpython.github.io/dpctl/latest/docfiles/dpctl/SyclDevice.html)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/02-dpnp_numpy_fallback.ipynb
+++ b/notebooks/02-dpnp_numpy_fallback.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be340585",
+   "metadata": {},
+   "source": [
+    "# Usage of numpy functions in dpnp library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9008dbe5",
+   "metadata": {},
+   "source": [
+    "1. Example of the usage of the `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` environment variable and finding specific values in array based on condition using dpnp library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d4300fe",
+   "metadata": {},
+   "source": [
+    "Not all functions were yet implemented in the dpnp library, some of the functions require enabling of the direct fallback to the NumPy library. \n",
+    "One of the example can be the function \"dpnp.full ()\" and parameter like in non default state. \n",
+    "Let's look on the example where we want to create an two dimencial array with singular element and array like option. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c78511cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "Requested funtion=full with args=((2, 2), 3, None, 'C') and kwargs={'like': <dpnp.dpnp_array.dpnp_array object at 0x0000021C7FAAF8B0>} isn't currently supported and would fall back on NumPy implementation. Define enviroment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` if the fall back is required to be supported without rasing an exception.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[1], line 4\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mdpnp\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;66;03m# Create an two dimencial array with singular element and array like option\u001b[39;00m\n\u001b[1;32m----> 4\u001b[0m a \u001b[38;5;241m=\u001b[39m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfull\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m3\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlike\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mzeros\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      5\u001b[0m \u001b[38;5;28mprint\u001b[39m (\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mArray a is located on the device:\u001b[39m\u001b[38;5;124m\"\u001b[39m, a\u001b[38;5;241m.\u001b[39mdevice)\n\u001b[0;32m      6\u001b[0m \u001b[38;5;28mprint\u001b[39m (\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mArray a is\u001b[39m\u001b[38;5;124m\"\u001b[39m, a)\n",
+      "File \u001b[1;32m~\\Anaconda3\\envs\\my_env\\lib\\site-packages\\dpnp\\dpnp_iface_arraycreation.py:732\u001b[0m, in \u001b[0;36mfull\u001b[1;34m(shape, fill_value, dtype, order, like, device, usm_type, sycl_queue)\u001b[0m\n\u001b[0;32m    723\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m    724\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m dpnp_container\u001b[38;5;241m.\u001b[39mfull(shape,\n\u001b[0;32m    725\u001b[0m                                fill_value,\n\u001b[0;32m    726\u001b[0m                                dtype\u001b[38;5;241m=\u001b[39mdtype,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m    729\u001b[0m                                usm_type\u001b[38;5;241m=\u001b[39musm_type,\n\u001b[0;32m    730\u001b[0m                                sycl_queue\u001b[38;5;241m=\u001b[39msycl_queue)\n\u001b[1;32m--> 732\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mcall_origin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnumpy\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfull\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshape\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfill_value\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43morder\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlike\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlike\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[1;32mdpnp\\dpnp_utils\\dpnp_algo_utils.pyx:132\u001b[0m, in \u001b[0;36mdpnp.dpnp_utils.dpnp_algo_utils.call_origin\u001b[1;34m()\u001b[0m\n",
+      "\u001b[1;31mNotImplementedError\u001b[0m: Requested funtion=full with args=((2, 2), 3, None, 'C') and kwargs={'like': <dpnp.dpnp_array.dpnp_array object at 0x0000021C7FAAF8B0>} isn't currently supported and would fall back on NumPy implementation. Define enviroment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` if the fall back is required to be supported without rasing an exception."
+     ]
+    }
+   ],
+   "source": [
+    "import dpnp as np\n",
+    "\n",
+    "# Create an two dimencial array with singular element and array like option\n",
+    "a = np.full((2,2),3, like = np.zeros((2, 0)))\n",
+    "print (\"Array a is located on the device:\", a.device)\n",
+    "print (\"Array a is\", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae026021",
+   "metadata": {},
+   "source": [
+    "As you can see the function \"dpnp.full ()\" and parameter like in non default state is not implemented in the dpnp library.\n",
+    "We got the following error message: \"Requested funtion=full with args=((2, 2), 3, None, 'C') and kwargs={'like': <dpnp.dpnp_array.dpnp_array object at 0x0000021C7FAAF8B0>} isn't currently supported and would fall back on NumPy implementation. Define environment variable `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` to `0` if the fall back is required to be supported without raising an exception.\" \n",
+    "By default the `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK` environment variable is not null and it allows to use only dpnp library. \n",
+    "If we want to call NumPy library for functions not supported under dpnp, we need to change this environment variable to `0`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "210440c3",
+   "metadata": {},
+   "source": [
+    "Let's overwrite the same example using the `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0` environment variable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bca7490d",
+   "metadata": {},
+   "source": [
+    "`Note:` Please pay attention that if you are working in the Jupyter Notebook, before running the example with setting the  `DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0` you need to restart the kernel in the Jupyter Notebook. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "05ad1565",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK = 0\n",
+      "Array a is located on the device: Device(level_zero:gpu:0)\n",
+      "Array a is [[3 3]\n",
+      " [3 3]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "# call numpy if not null than we will use dpnp, by default not null\n",
+    "os.environ[\"DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK\"] = \"0\" \n",
+    "\n",
+    "import dpnp as np\n",
+    "\n",
+    "# Expect result 0\n",
+    "print (\"DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK =\", np.config.__DPNP_RAISE_EXCEPION_ON_NUMPY_FALLBACK__) \n",
+    "\n",
+    "# Create an two dimencial array with singular element and array like option\n",
+    "a = np.full((2,2),3, like = np.zeros((2, 0)))\n",
+    "print (\"Array a is located on the device:\", a.device)\n",
+    "print (\"Array a is\", a)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Significant refactoring in Jupyter Notebooks.

- conf.py implements copying `/notebooks` directory to `docs/src/notebooks` on each build (working around the issue that nbsphinx can only handle notebooks located within `/src`
- rewrote some Jupyter examples and significantly reworked text